### PR TITLE
Syntax change, DerefMut, support #[derive()]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-target
+target/
 Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+
+os:
+    - linux
+
+script:
+    - cargo test -v
+    - cd doctest && cargo test -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,4 @@ authors = ["Arien Malec <arien.malec@gmail.com>"]
 
 [lib]
 name = "newtype_macros"
-crate-type = ["dylib"]
 plugin = true

--- a/README.md
+++ b/README.md
@@ -16,43 +16,38 @@ Many people have created macros to automate this, and perform the equivalent of 
 
 ## Usage
 
-This library provides two macros: `newtype_derive!` and `newtype!`. The first operates on an existing newtype definition and allows configurable derivation of the traits `Deref`, `From`, `Into`, `Display`, `Add`, `Sub`, `Mul`, `Div`, and `Neg`. The second creates the newtype, provides basic Rust derives (`Debug` and partial equality/ordering).
+This library provides two macros: `newtype_derive!` and `newtype!`. The first operates on an existing newtype definition and allows configurable derivation of the traits `Deref`, `DerefMut`, `From`, `Into`, `Display`, `Add`, `Sub`, `Mul`, `Div`, and `Neg`. The second creates the newtype, provides basic Rust derives (`Debug` and partial equality/ordering).
 
 `From`, `Into`, and `Deref` provide (respectively) basic conversion from/to the underlying value, and provide access to a reference to the underlying value value. The other defaults delegate to the underlying value for display and arithmetic operations.
-
 
 
 ```rust
 #[macro_use]
 extern crate newtype_macros;
-use std::convert::{From,Into};
-use std::ops::{Add,Mul,Sub,Div,Neg,Deref};
-use std::fmt::{self,Display};
 
 fn main() {
-    newtype!(Miles,u32,Display,From,Into,Deref,Add);
+    newtype!(struct Miles(u32): Display, From, Into, Deref, Add);
     let m = Miles::from(14);
-    let m2:Miles = 7.into();
-    assert_eq!(*m,14);
-    assert_eq!(*m2,7);
-    print!("{} miles ",m);
-    print!("plus {} miles ",m2);
-    println!("is {} miles", m+m2);
+    let m2: Miles = 7.into();
+    assert_eq!(*m, 14);
+    assert_eq!(*m2, 7);
+    print!("{} miles ", m);
+    print!("plus {} miles ", m2);
+    println!("is {} miles", m + m2);
 }
 ```
 
 Arithmetic functions use `From` and `Into` to perform conversion to/from the underlying value. This is to allow, for example, preliminary conversion to be implemented via `From` and `Into` before delegating to the underlying type to perform the operations. Therefore, to add automatic derivations of these traits, either `From` and `Into` must also be derived, or must be manually implemented.
 
 ```rust
-newtype!(Miles,u32,From,Into,Add);
+newtype!(struct Miles(u32): Display, From, Into, Add);
 let m = Miles::from(500);
 let m2 = Miles::from(500);
-print!("I would walk {} miles/",m);
-print!("and I would walk {} more/,m2);
-println("just to be the man who walked a {} miles/to fall down at your door", m+m2);
+print!("I would walk {} miles/", m);
+print!("and I would walk {} more/, m2);
+println("just to be the man who walked a {} miles/to fall down at your door", m + m2);
 ```
 
 ## Limitations
 
-Hardwires the `#[define]`s in the `newtype!` macro. 
 Does not work at all with references (because of the need to declare lifetime specifiers)

--- a/doctest/Cargo.toml
+++ b/doctest/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+version = "0.0.0"
+name = "newtype_macros"
+
+[lib]
+name = "newtype_macros"
+path = "../src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,13 @@
-#[allow(unused_imports)]
-use std::convert::{From,Into};
-#[allow(unused_imports)]
-use std::ops::{Add,Mul,Sub,Div,Neg,Deref};
-#[allow(unused_imports)]
-use std::fmt::{self,Display};
+#![no_implicit_prelude]
+#![deny(missing_docs)]
+
+//! Rust Newtype Macros
+//!
+//! This library provides two macros: `newtype_derive!` and `newtype!`.
+//! The first operates on an existing newtype while the second creates the newtype.
+//!
+//! ## Limitations
+//! Does not work at all with references (because of the need to declare lifetime specifiers)
 
 
 /// Expands to a set of trait implementations for a newtype definition.
@@ -12,6 +16,7 @@ use std::fmt::{self,Display};
 /// - From -- converts from the wrapped type to the newtype
 /// - Into -- consumes the alias type and returns the wrapped type
 /// - Deref -- provides a reference to the wrapped type
+/// - DerefMut -- provides a mutable reference to the wrapped type
 /// - Display -- delegates to the wrapped type for display
 /// - The following arithmetic traits which delegate to the wrapped type
 ///   (and which require implementations of From and Into):
@@ -22,188 +27,226 @@ use std::fmt::{self,Display};
 /// -- Neg
 ///
 /// # Examples
+/// ```
 /// # #[macro_use] extern crate newtype_macros;
-/// # # fn main() {
+/// # fn main() {
 /// struct Miles(u32);
-/// newtype_derive!(Miles,u32,Display,From,Into,Deref);
+/// newtype_derive!(Miles(u32): Display, From, Into, Deref);
+///
 /// let m = Miles::from(14);
-/// let m2:Miles = 14.into();
-/// assert_eq!(*m,14);
-/// assert_eq!(*m2,14);
-/// assert_eq!(String::from("14"),format!("{}",m));
-/// # # }
-
+/// let m2: Miles = 14.into();
+/// assert_eq!(*m, 14);
+/// assert_eq!(*m2, 14);
+/// assert_eq!(String::from("14"), format!("{}", m));
+/// # }
+/// ```
 #[macro_export]
 macro_rules! newtype_derive {
-    () => (());
-    ($alias:ident, $t:ty, Deref) => {
-        impl Deref for $alias {
+    ($alias:ident($t:ty): ) => { };
+    ($alias:ident($t:ty): Deref) => {
+        impl ::std::ops::Deref for $alias {
             type Target = $t;
             fn deref<'a>(&'a self) -> &'a $t {
-                let $alias(ref v) = *self;
+                let &$alias(ref v) = self;
                 v
             }
-        }       
+        }
     };
-    ($alias:ident, $t:ty, From) => {
-        impl From<$t> for $alias {
+    ($alias:ident($t:ty): DerefMut) => {
+        impl ::std::ops::DerefMut for $alias {
+            fn deref_mut<'a>(&'a mut self) -> &'a mut $t {
+                let &mut $alias(ref mut v) = self;
+                v
+            }
+        }
+    };
+    ($alias:ident($t:ty): From) => {
+        impl ::std::convert::From<$t> for $alias {
             fn from(v: $t) -> Self {
                 $alias(v)
             }
         }
     };
-    ($alias:ident, $t:ty, Into) => {
-        impl Into<$t> for $alias {
+    ($alias:ident($t:ty): Into) => {
+        impl ::std::convert::Into<$t> for $alias {
             fn into(self) -> $t {
                 let $alias(v) = self;
                 v
             }
         }
     };
-    ($alias:ident, $t:ty, Display) => {
-        impl Display for $alias {
-             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    ($alias:ident($t:ty): Display) => {
+        impl ::std::fmt::Display for $alias {
+             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 let $alias(ref v) = *self;
-                v.fmt(f)
+                <$t as ::std::fmt::Display>::fmt(v, f)
             }
         }
     };
-    ($alias:ident, $t:ty, Add) => {
-        impl Add for $alias {
+    ($alias:ident($t:ty): Add) => {
+        impl ::std::ops::Add for $alias {
             type Output = $alias;
-            fn add(self, _rhs: $alias) -> Self {
-                let l: $t = self.into();
-                let r: $t = _rhs.into();
-                $alias::from(l + r)
+            fn add(self, rhs: $alias) -> Self {
+                let l = ::std::convert::Into::<$t>::into(self);
+                let r = ::std::convert::Into::<$t>::into(rhs);
+                ::std::convert::From::<$t>::from(l.add(r))
             }
         }
     };
-    ($alias:ident, $t:ty, Sub) => {
-        impl Sub for $alias {
+    ($alias:ident($t:ty): Sub) => {
+        impl ::std::ops::Sub for $alias {
             type Output = $alias;
-            fn sub(self, _rhs: $alias) -> Self {
-                let l: $t = self.into();
-                let r: $t = _rhs.into();
-                $alias::from(l - r)
+            fn sub(self, rhs: $alias) -> Self {
+                let l = ::std::convert::Into::<$t>::into(self);
+                let r = ::std::convert::Into::<$t>::into(rhs);
+                ::std::convert::From::<$t>::from(l.sub(r))
             }
         }
     };
-    ($alias:ident, $t:ty, Mul) => {
-        impl Mul for $alias {
+    ($alias:ident($t:ty): Mul) => {
+        impl ::std::ops::Mul for $alias {
             type Output = $alias;
-            fn mul(self, _rhs: $alias) -> Self {
-                let l: $t = self.into();
-                let r: $t = _rhs.into();
-                $alias::from(l * r)
+            fn mul(self, rhs: $alias) -> Self {
+                let l = ::std::convert::Into::<$t>::into(self);
+                let r = ::std::convert::Into::<$t>::into(rhs);
+                ::std::convert::From::<$t>::from(l.mul(r))
             }
         }
     };
-    ($alias:ident, $t:ty, Div) => {
-        impl Div for $alias {
+    ($alias:ident($t:ty): Div) => {
+        impl ::std::ops::Div for $alias {
             type Output = $alias;
-            fn div(self, _rhs: $alias) -> Self {
-                let l: $t = self.into();
-                let r: $t = _rhs.into();
-                $alias::from(l / r)
+            fn div(self, rhs: $alias) -> Self {
+                let l = ::std::convert::Into::<$t>::into(self);
+                let r = ::std::convert::Into::<$t>::into(rhs);
+                ::std::convert::From::<$t>::from(l.div(r))
             }
         }
     };
-    ($alias:ident, $t:ty, Neg) => {
-        impl Neg for $alias {
+    ($alias:ident($t:ty): Neg) => {
+        impl ::std::ops::Neg for $alias {
             type Output = $alias;
             fn neg(self) -> Self {
-                let v: $t = self.into();
-                $alias::from(-v)
+                let v = ::std::convert::Into::<$t>::into(self);
+                ::std::convert::From::<$t>::from(v.neg())
             }
         }
     };
-    ($alias:ident, $t:ty, $($keyword:ident),*) => {
-        $(newtype_derive!($alias, $t, $keyword);)*
+    ($alias:ident($t:ty): $keyword:ident) => { unrecognized derive keyword };
+    ($alias:ident($t:ty): $($keyword:ident),*) => {
+        $(newtype_derive!($alias($t): $keyword);)*
     };
-
 }
 
 /// Expands to a newtype defintion with basic derives, and uses newtype_derive! to derive traits
 ///
-/// Supports same traits as newtype_derive!, and additionally inserts #[define] attributes for
-/// Debug, PartialEq and PartialOrd (assumes the underlying trait supports these as well)
+/// Supports same traits as newtype_derive!
 ///
 /// # Examples
+/// ```
 /// # #[macro_use] extern crate newtype_macros;
-/// # # fn main() {
-/// newtype!(Miles,u32,From,Into,Add);
+/// newtype!(#[derive(Debug, PartialEq)] pub struct Miles(u32): From, Into, Add);
+/// # fn main() {
 /// let m = Miles::from(14);
 /// let m2 = Miles::from(20);
-/// assert_eq!(Miles::from(34),m+m2);
-/// # # }
-
+/// assert_eq!(Miles::from(34), m + m2);
+/// # }
+/// ```
 #[macro_export]
 macro_rules! newtype {
-    ($alias:ident, $t:ty, $($keyword:ident),*) => {
-        #[derive(Debug,PartialEq,PartialOrd)]
+    ($(#[$meta:meta])* struct $alias:ident($t:ty): $($keyword:ident),*) => {
+        $(#[$meta])*
         struct $alias($t);
-        $(newtype_derive!($alias, $t, $keyword);)*
+
+        $(newtype_derive!($alias($t): $keyword);)*
+    };
+    ($(#[$meta:meta])* pub struct $alias:ident($t:ty): $($keyword:ident),*) => {
+        $(#[$meta])*
+        pub struct $alias($t);
+
+        $(newtype_derive!($alias($t): $keyword);)*
+    };
+}
+
+#[test]
+#[allow(dead_code)]
+fn test_no_prelude() {
+    newtype!(struct M1(i32): Deref);
+    newtype!(struct M2(i32): Deref, DerefMut);
+    newtype!(struct M3(i32): From);
+    newtype!(struct M4(i32): Into);
+    newtype!(struct M5(i32): Display);
+    newtype!(struct M6(i32): From, Into, Add);
+    newtype!(struct M7(i32): From, Into, Sub);
+    newtype!(struct M8(i32): From, Into, Mul);
+    newtype!(struct M9(i32): From, Into, Div);
+    newtype!(struct M10(i32): From, Into, Neg);
+    newtype!(#[derive(Hash)] struct M11(i32): Deref);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::prelude::v1::*;
+
+    #[test]
+    fn test_newtype_derive() {
+        struct Miles(u32);
+        newtype_derive!(Miles(u32): Display, From, Into, Deref);
+        let m = Miles::from(14);
+        let m2: Miles = 14.into();
+        assert_eq!(*m, 14);
+        assert_eq!(*m2, 14);
+        assert_eq!(String::from("14"), format!("{}", m));
+
     }
-}
 
-#[test]
-fn test_newtype_derive() {
-    struct Miles(u32);
-    newtype_derive!(Miles,u32,Display,From,Into,Deref);
-    let m = Miles::from(14);
-    let m2:Miles = 14.into();
-    assert_eq!(*m,14);
-    assert_eq!(*m2,14);
-    assert_eq!(String::from("14"),format!("{}",m));
+    #[test]
+    fn test_newtype() {
+        newtype!(#[derive(Debug, PartialEq)] struct Miles(u32): Display, From, Into, Deref);
+        let m = Miles::from(14);
+        let m2: Miles = 14.into();
+        assert_eq!(*m,14);
+        assert_eq!(*m2,14);
+        assert_eq!(String::from("14"), format!("{}", m));
 
-}
+    }
 
-#[test]
-fn test_newtype() {
-    newtype!(Miles,u32,Display,From,Into,Deref);
-    let m = Miles::from(14);
-    let m2:Miles = 14.into();
-    assert_eq!(*m,14);
-    assert_eq!(*m2,14);
-    assert_eq!(String::from("14"),format!("{}",m));
+    #[test]
+    fn test_add() {
+        newtype!(#[derive(Debug, PartialEq)] struct Miles(u32): From, Into, Add);
+        let m = Miles::from(14);
+        let m2 = Miles::from(20);
+        assert_eq!(Miles::from(34), m + m2);
+    }
 
-}
+    #[test]
+    fn test_sub() {
+        newtype!(#[derive(Debug, PartialEq)] struct Miles(u32): From, Into, Sub);
+        let m = Miles::from(20);
+        let m2 = Miles::from(14);
+        assert_eq!(Miles::from(6), m - m2);
+    }
 
-#[test]
-fn test_add() {
-    newtype!(Miles,u32,From,Into,Add);
-    let m = Miles::from(14);
-    let m2 = Miles::from(20);
-    assert_eq!(Miles::from(34),m+m2);
-}
+    #[test]
+    fn test_mul() {
+        newtype!(#[derive(Debug, PartialEq)] struct Miles(u32): From, Into, Mul);
+        let m = Miles::from(14);
+        let m2 = Miles::from(20);
+        assert_eq!(Miles::from(280), m * m2);
+    }
 
-#[test]
-fn test_sub() {
-    newtype!(Miles,u32,From,Into,Sub);
-    let m = Miles::from(20);
-    let m2 = Miles::from(14);
-    assert_eq!(Miles::from(6),m-m2);
-}
+    #[test]
+    fn test_div() {
+        newtype!(#[derive(Debug, PartialEq)] struct Miles(f64): From, Into, Div);
+        let m = Miles::from(20f64);
+        let m2 = Miles::from(5f64);
+        assert_eq!(Miles::from(4f64), m / m2);
+    }
 
-#[test]
-fn test_mul() {
-    newtype!(Miles,u32,From,Into,Mul);
-    let m = Miles::from(14);
-    let m2 = Miles::from(20);
-    assert_eq!(Miles::from(280),m*m2);
-}
-
-#[test]
-fn test_div() {
-    newtype!(Miles,f64,From,Into,Div);
-    let m = Miles::from(20f64);
-    let m2 = Miles::from(5f64);
-    assert_eq!(Miles::from(4f64),m/m2);
-}
-
-#[test]
-fn test_neg() {
-    newtype!(Miles,i32,From,Into,Neg);
-    let m = Miles::from(20);
-    assert_eq!(Miles::from(-20),-m);
+    #[test]
+    fn test_neg() {
+        newtype!(#[derive(Debug, PartialEq)] struct Miles(i32): From, Into, Neg);
+        let m = Miles::from(20);
+        assert_eq!(Miles::from(-20), -m);
+    }
 }


### PR DESCRIPTION
Includes a syntax change, doctest support (cargo seems to not allow doctests on plugin libs for some reason), DerefMut, support for #[derive()], and pub structs.

Not sure how much of this you want to pull in, if any, but I feel like it improves the macro a fair bit.
